### PR TITLE
Added config.useISO8601 to control the %{TIMESTAMP} date format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The following configuration properties are available:
 | context          | Variables that can be referenced in log messages for a specific logger   | {}                                                   | instance method, constructor        |
 | errorWriter      | Function for writing log messages at FATAL or ERROR levels               | console.error()                                      | constructor, static method          |
 | logWriter        | Function for writing log messages at any level other than FATAL or ERROR | console.log()                                        | constructor, static method          |
+| useISO8601       | true: TIMESTAMP uses [ISO8601][iso8601] date format, false: it uses [ECMA262][ecma262] date format. | true                      | constructor                         |
 
 Note that the timestamp is automatically omitted from the default log format when Sitka detects an AWS Lambda or Google Cloud environment since they add their own timestamp prefix.
 
@@ -204,7 +205,7 @@ Both the log format and log messages may contain the following variables using t
 * `LEVEL`: The log level for this log entry
 * `MESSAGE`: The provided log message
 * `NAME`: The name of the current logger (only available in log format)
-* `TIMESTAMP`: Date and time the entry was logged
+* `TIMESTAMP`: Date and time the entry was logged (its value depends on `useISO8601` config property)
 * `CTX:VAR_NAME`: Value of the VAR_NAME property from the log context
 * `ENV:VAR_NAME`: The value of the VAR_NAME environment variable
 
@@ -231,6 +232,9 @@ export LOG_FORMAT='[${TIMESTAMP}] [${LEVEL}] [${NAME}] ${MESSAGE}'
 
 # Specify a different log format for the logger named MyLogger:
 export LOG_FORMAT_MyLogger='[${TIMESTAMP}] [${LEVEL}] [${NAME}] [${ENV:AWS_REGION}] ${MESSAGE}'
+
+# Specify if the default date format for TIMESTAMP will be ISO8601 (true) or ECMA262 (false):
+export USE_ISO8601='false'
 ```
 
 While the `LOG_LEVEL` environment variable doesn't need the `Logger.Level.` prefix as used in code, it can be used if preferred. In either case, the value must be present in the `Logger.Level` enum for it to take effect.
@@ -267,3 +271,5 @@ Sitka aims to remain lightweight with a focus on simple flexibility over complex
 [dependencies-url]: https://david-dm.org/chriswells0/node-sitka
 [dev-dependencies-image]: https://david-dm.org/chriswells0/node-sitka/dev-status.svg
 [dev-dependencies-url]: https://david-dm.org/chriswells0/node-sitka?type=dev
+[ecma262]: https://www.ecma-international.org/ecma-262/#sec-date.prototype.tostring
+[iso8601]: https://www.iso.org/iso-8601-date-and-time-format.html


### PR DESCRIPTION
This PR adds:
- A new configuration property: `useISO8601`
- A new environment variable: `USE_ISO8601`

Both of them to control the date format of the `%{TIMESTAMP}` log format variable.

Also new tests were added to validate their functionality.

### Background
Currently, The variable `TIMESTAMP` returns a String with the ECMA262 representation of a date.

Real examples:

* `'Sun Sep 20 2020 19:28:45 GMT+0000 (Coordinated Universal Time)'` (62 characters)
* `'Sun Sep 20 2020 16:59:30 GMT-0300 (Brasilia Standard Time)'` (58 characters)
* `'Sun Sep 20 2020 17:02:47 GMT-0300 (Horário Padrão de Brasília)'` (62 characters, utf8: 65 bytes)
* etc.

This could be fine for most of the cases, but it has some issues:
- It generates non-portable text, as `Date()` returns different values in different contexts (even depending on the ecma implementation), making difficult to parse it for some use cases.
- It's impossible to sort the log by timestamp without parsing the timestamp (e.g. several logs concatenated to get information).
- The size of the log is affected, as it needs more space than required to represent a timestamp.

In the README.md, the basic example shows the TIMESTAMP as a date in ISO8601 format, which, IMO, should be the default date format.
- JSON spec doesn't define a specific date format, however as javascript's method `JSON.stringify()` uses ISO8601 for date fields, this format has been broadly used as a JSON date format, so it's the natural choice to generate JSON logs.
- The  `toISOString()` that returns ISO8601 strings, only requires 24 characters, reducing the log size.

To use the ISO8601 date format, it could be enough replacing in the code `Date()` with `new Date().toISOString()`, however it can brake clients of sitka that may be parsing the date string with 3rd tools (e.g. shell scripts), so changing it may require extra work for them.

So, I think it would be better adding a new configuration property  (`useISO8601`) and use a new environment variable (`USE_ISO8601`) with `true` as predefined value. This way, if some users want the ECMA date format, they can get it simply changing the configuration or setting the environment variable.
