### PR TITLE
Support for SITKA_LEVEL, SITKA_FORMAT, and SITKA_ISO8601 variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ While you can always use a custom string for the format, several constants are p
 
 ### Environment Variables
 
-The log level and format can be controlled globally as well as for individual loggers using environment variables:
+The log level, format, and date format can be controlled globally as well as for individual loggers using environment variables `LOG_LEVEL`, `LOG_FORMAT`, and `USE_ISO8601`. However, in environments where 
+these variables interfere with other npm packages or systems, the `SITKA_LEVEL`, `SITKA_FORMAT`, 
+and `SITKA_ISO8601` can be used.
 
 ```bash
 # Only log ERROR and higher level messages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,9 +511,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
     "@types/minimist": {
@@ -983,14 +983,14 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -1017,7 +1017,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
@@ -1660,9 +1660,9 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
+      "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -2153,7 +2153,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-package-type": {
@@ -3150,9 +3150,9 @@
       "dev": true
     },
     "loupe": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.1.tgz",
-      "integrity": "sha512-EN1D3jyVmaX4tnajVlfbREU4axL647hLec1h/PXAb8CPDMJiYitcWF2UeLVNttRqaIqQs4x+mRvXf+d+TlDrCA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,25 +102,26 @@ export class Logger {
 	private constructor(config: ILogConfigWithName) {
 		this._name = config.name;
 		this._context = config.context || {};
-		const envLogLevel: string = this.getEnvVariable('LOG_LEVEL', true).replace(/Log(ger\.)?Level\./, '');
+		const envLogLevel: string = (
+					   this.getEnvVariable('SITKA_LEVEL', true) 
+					|| this.getEnvVariable('LOG_LEVEL', true)).replace(/Log(ger\.)?Level\./, '');
 		this._level = config.level
 					|| (LogLevel.hasOwnProperty(envLogLevel) && LogLevel[envLogLevel as keyof typeof LogLevel])
 					|| LogLevel.ALL;
 		this._logWriter = config.logWriter || undefined;
 		this._errorWriter = config.errorWriter || undefined;
 		this._format = config.format
+					|| this.getEnvVariable('SITKA_FORMAT', true)
 					|| this.getEnvVariable('LOG_FORMAT', true)
 					|| (this.getEnvVariable('LAMBDA_TASK_ROOT') || this.getEnvVariable('GCP_PROJECT')
 						? LogFormat.TEXT_NO_TIME : LogFormat.TEXT);
 		// Perform static replacements now so fewer are needed for each log entry. -- cwells
 		this._format = this._format.replace(this._regexEscapedVar, '$1_SITKA_ESCAPED_VAR_{')
 									.replace(/[$%]\{NAME\}/g, this._name);
-		const envUseISO8601 = this.getEnvVariable('USE_ISO8601', true);
-		this._useISO8601 = typeof config.useISO8601 === 'boolean'
-						? config.useISO8601
-						: ['true', 'false'].includes(envUseISO8601)
-							? envUseISO8601 === 'true'
-							: true;
+		const envUseISO8601 = 
+					   this.getEnvVariable('SITKA_ISO8601', true)
+					|| this.getEnvVariable('USE_ISO8601', true);
+		this._useISO8601 = envUseISO8601 !== 'false';
 	}
 
 	/* Public Instance Methods */


### PR DESCRIPTION
### Issue

While I was working on my own projects (all of them using the Sitka logger), everything was fine. 

However, as soon as I started to interact with other npm packages and/or projects using different loggers, I realized that there was no easy way to configure the Sitka using environment variables, because they affected not only my packages, but also the log of other packages that don't use Sitka as logger.

### Solution

Sitka should support new environment variables with prefix "SITKA_" as well as the existent "LOG_" ones, and the former ones should be prioritized.